### PR TITLE
Update Finger Toggle

### DIFF
--- a/Assets/Prefabs/ButtonToggle.prefab
+++ b/Assets/Prefabs/ButtonToggle.prefab
@@ -86,6 +86,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4805335380489893670}
   - component: {fileID: 8244155296428721821}
+  - component: {fileID: 300998192581130457}
   m_Layer: 5
   m_Name: ButtonToggle
   m_TagString: Untagged
@@ -159,8 +160,34 @@ MonoBehaviour:
   m_Group: {fileID: 0}
   onValueChanged:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 300998192581130457}
+        m_TargetAssemblyTypeName: FingerToggle, Assembly-CSharp
+        m_MethodName: ToggleClick
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_IsOn: 1
+--- !u!114 &300998192581130457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3939263650187549322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f35dc65e40582448814cee315e9eb08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ToggleGroup: {fileID: 0}
+  SerialNumber: 0
 --- !u!1 &7447248920764567826
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Battle.unity
+++ b/Assets/Scenes/Battle.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311924, g: 0.38073963, b: 0.3587269, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -240,6 +240,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 495051f36ab41704fa570a27672d1e40, type: 3}
+    - target: {fileID: 300998192581130457, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: _ToggleGroup
+      value: 
+      objectReference: {fileID: 256148339}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
       value: OneButton
@@ -492,6 +496,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 09dca4982a9ff5e4f9a4c555b71bacb5, type: 3}
+    - target: {fileID: 300998192581130457, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: _ToggleGroup
+      value: 
+      objectReference: {fileID: 256148339}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
       value: FoutButton
@@ -608,6 +616,7 @@ GameObject:
   m_Component:
   - component: {fileID: 256148340}
   - component: {fileID: 256148341}
+  - component: {fileID: 256148342}
   m_Layer: 5
   m_Name: FingerToggleGroup
   m_TagString: Untagged
@@ -648,7 +657,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2fafe2cfe61f6974895a912c3755e8f1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_AllowSwitchOff: 1
+  m_AllowSwitchOff: 0
+--- !u!114 &256148342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256148339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50e6923ce91f72943b9fc08f3c552cea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SelectedFinger: 0
 --- !u!1 &573423204
 GameObject:
   m_ObjectHideFlags: 0
@@ -1018,6 +1040,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 7d64b8fc9afcee04a9803531677ccab5, type: 3}
+    - target: {fileID: 300998192581130457, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: _ToggleGroup
+      value: 
+      objectReference: {fileID: 256148339}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
       value: ThreeButton
@@ -1341,6 +1367,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 605250897}
     m_Modifications:
+    - target: {fileID: 300998192581130457, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: _ToggleGroup
+      value: 
+      objectReference: {fileID: 256148339}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
       value: ZeroButton
@@ -1427,12 +1457,36 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_IsOn
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Group
       value: 
       objectReference: {fileID: 256148341}
+    - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: m_Colors.m_PressedColor.b
+      value: 0.78431374
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: m_Colors.m_PressedColor.g
+      value: 0.78431374
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: m_Colors.m_PressedColor.r
+      value: 0.78431374
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.r
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1455,6 +1509,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 5ed139a8d2a5aa540914be05c743888e, type: 3}
+    - target: {fileID: 300998192581130457, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: _ToggleGroup
+      value: 
+      objectReference: {fileID: 256148339}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
       value: TwoButton
@@ -1573,6 +1631,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 21300000, guid: 3384e6fc032fe8a479a62e9ba22f2a7c, type: 3}
+    - target: {fileID: 300998192581130457, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+      propertyPath: _ToggleGroup
+      value: 
+      objectReference: {fileID: 256148339}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
       value: FiveButton

--- a/Assets/Scripts/Battle.meta
+++ b/Assets/Scripts/Battle.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 154a85f1a3646f2429ac71ed78fe1cfe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/FingerToggle.cs
+++ b/Assets/Scripts/Battle/FingerToggle.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class FingerToggle : MonoBehaviour
+{
+    // Start is called before the first frame update
+    private Toggle _Toggle;
+    [SerializeField]private GameObject _ToggleGroup;
+    [SerializeField] private int SerialNumber;
+    private FingerToggleGroup _FingerToggleGroup;
+    void Start()
+    {
+        _Toggle = GetComponent<Toggle>();
+        _FingerToggleGroup = _ToggleGroup.GetComponent<FingerToggleGroup>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+    public void ToggleClick(bool isOn)
+    {
+        _FingerToggleGroup.SelectedFinger = SerialNumber;
+    }
+}

--- a/Assets/Scripts/Battle/FingerToggle.cs.meta
+++ b/Assets/Scripts/Battle/FingerToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f35dc65e40582448814cee315e9eb08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Battle/FingerToggleGroup.cs
+++ b/Assets/Scripts/Battle/FingerToggleGroup.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FingerToggleGroup : MonoBehaviour
+{
+    // Start is called before the first frame update
+    public int SelectedFinger = 0;
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+}

--- a/Assets/Scripts/Battle/FingerToggleGroup.cs.meta
+++ b/Assets/Scripts/Battle/FingerToggleGroup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50e6923ce91f72943b9fc08f3c552cea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. Battle Scene의 ToggleGroup에 SelectedFinger라는 이름의 public int 변수를 선언했습니다. 이 변수가 그 플레이어가 고른 손가락을 의미하는 변수이므로 추후 이 변수를 가져오는 방식으로 플레이어가 어떤 손가락을 골랐는지 확인하면 될 것 같습니다.
2. Toggle들을 눌렀을 때 어둡게 변하는 것과, 더블 클릭 시 선택이 해제되는 기능을 없앴습니다. 플레이어는 반드시 하나의 토글을 고르게 됩니다.
3. 각각의 Toggle에 스크립트를 추가해서 선택 시 SelectedFinger 변수가 변하도록 했습니다.
4. Script 폴더 내에 Battle이라는 Battle Scene을 위한 하위 폴더를 더 추가했습니다.