### PR TITLE
플레이어 손가락 선택 여부 확인 및 토글 초기화

### DIFF
--- a/Assets/Scenes/Battle.unity
+++ b/Assets/Scenes/Battle.unity
@@ -1547,12 +1547,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fingerToggleGroup: {fileID: 256148342}
-  ZeroButton: {fileID: 1476963261}
-  OneButton: {fileID: 893480637}
-  TwoButton: {fileID: 1894451313}
-  ThreeButton: {fileID: 1770277222}
-  FourButton: {fileID: 741200673}
-  FiveButton: {fileID: 2096674927}
+  Buttons:
+  - {fileID: 1476963261}
+  - {fileID: 893480637}
+  - {fileID: 1894451313}
+  - {fileID: 1770277222}
+  - {fileID: 741200673}
+  - {fileID: 2096674927}
   TargetPlayer0Done: {fileID: 97880151}
   TargetPlayer1Done: {fileID: 1878852114}
   TargetCanvas: {fileID: 7628541}

--- a/Assets/Scenes/Battle.unity
+++ b/Assets/Scenes/Battle.unity
@@ -520,7 +520,7 @@ PrefabInstance:
       objectReference: {fileID: 256148342}
     - target: {fileID: 3939263650187549322, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Name
-      value: FoutButton
+      value: FourButton
       objectReference: {fileID: 0}
     - target: {fileID: 4359160644566970796, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
       propertyPath: m_Sprite
@@ -1163,6 +1163,17 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &741200673 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+  m_PrefabInstance: {fileID: 89236606}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &744334688
 GameObject:
   m_ObjectHideFlags: 0
@@ -1403,6 +1414,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &893480637 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+  m_PrefabInstance: {fileID: 21761931}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1075158458
 GameObject:
   m_ObjectHideFlags: 0
@@ -1524,6 +1546,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a4fad676d05cd7a45949366010c45301, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  fingerToggleGroup: {fileID: 256148342}
+  ZeroButton: {fileID: 1476963261}
+  OneButton: {fileID: 893480637}
+  TwoButton: {fileID: 1894451313}
+  ThreeButton: {fileID: 1770277222}
+  FourButton: {fileID: 741200673}
+  FiveButton: {fileID: 2096674927}
   TargetPlayer0Done: {fileID: 97880151}
   TargetPlayer1Done: {fileID: 1878852114}
   TargetCanvas: {fileID: 7628541}
@@ -2289,6 +2318,28 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4805335380489893670, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
   m_PrefabInstance: {fileID: 1476963258}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1476963261 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+  m_PrefabInstance: {fileID: 1476963258}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1770277222 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+  m_PrefabInstance: {fileID: 1174341263}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1878852114
 GameObject:
   m_ObjectHideFlags: 0
@@ -2457,6 +2508,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4805335380489893670, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
   m_PrefabInstance: {fileID: 1894451310}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1894451313 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+  m_PrefabInstance: {fileID: 1894451310}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2096674924
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2587,6 +2649,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 4805335380489893670, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
   m_PrefabInstance: {fileID: 2096674924}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2096674927 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8244155296428721821, guid: 59a3601c199b340eca07b3a15d8a4f08, type: 3}
+  m_PrefabInstance: {fileID: 2096674924}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battle/FingerToggle.cs
+++ b/Assets/Scripts/Battle/FingerToggle.cs
@@ -31,6 +31,5 @@ public class FingerToggle : MonoBehaviour
         {
             _FingerToggleGroup.SelectedFinger = -1;
         }
-        Debug.Log(_FingerToggleGroup.SelectedFinger.ToString());
     }
 }

--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -6,6 +6,8 @@ public class UIManager : MonoBehaviour
 {
     public FingerToggleGroup fingerToggleGroup;
 
+    [SerializeField] private List<Toggle> Buttons;
+
     public GameObject TargetPlayer0Done;
     public GameObject TargetPlayer1Done;
     public GameObject TargetCanvas;
@@ -30,8 +32,6 @@ public class UIManager : MonoBehaviour
             }
             curPlayer = (curPlayer == 0) ? 1 : 0;
 
-            List<Toggle> Buttons = new();
-            Buttons.AddRange(fingerToggleGroup.GetComponentsInChildren<Toggle>());
             Buttons[fingerToggleGroup.SelectedFinger].isOn = false;
         }
     }

--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -6,13 +5,6 @@ using UnityEngine.UI;
 public class UIManager : MonoBehaviour
 {
     public FingerToggleGroup fingerToggleGroup;
-
-    public Toggle ZeroButton;
-    public Toggle OneButton;
-    public Toggle TwoButton;
-    public Toggle ThreeButton;
-    public Toggle FourButton;
-    public Toggle FiveButton;
 
     public GameObject TargetPlayer0Done;
     public GameObject TargetPlayer1Done;
@@ -26,39 +18,21 @@ public class UIManager : MonoBehaviour
     /// </summary>
     public void OnClickDoneButton()
     {
-        if (fingerToggleGroup.IsToggleClicked() == true) // check if player choose toggle
+        if (fingerToggleGroup.SelectedFinger != -1) // check if player choose toggle
         {
             if (curPlayer == 0)
             {
                 TargetPlayer0Done.transform.position = TargetCanvas.transform.position;
             }
-            else
+            else if (curPlayer == 1)
             {
                 TargetPlayer1Done.transform.position = TargetCanvas.transform.position;
             }
             curPlayer = (curPlayer == 0) ? 1 : 0;
 
-            switch (fingerToggleGroup.SelectedFinger)
-            {
-                case 0:
-                    ZeroButton.isOn = false;
-                    break;
-                case 1:
-                    OneButton.isOn = false;
-                    break;
-                case 2:
-                    TwoButton.isOn = false;
-                    break;
-                case 3:
-                    ThreeButton.isOn = false;
-                    break;
-                case 4:
-                    FourButton.isOn = false;
-                    break;
-                case 5:
-                    FiveButton.isOn = false;
-                    break;
-            }
+            List<Toggle> Buttons = new();
+            Buttons.AddRange(fingerToggleGroup.GetComponentsInChildren<Toggle>());
+            Buttons[fingerToggleGroup.SelectedFinger].isOn = false;
         }
     }
 

--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -1,43 +1,65 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UIElements;
+using UnityEngine.UI;
 
 public class UIManager : MonoBehaviour
 {
+    public FingerToggleGroup fingerToggleGroup;
+
+    public Toggle ZeroButton;
+    public Toggle OneButton;
+    public Toggle TwoButton;
+    public Toggle ThreeButton;
+    public Toggle FourButton;
+    public Toggle FiveButton;
+
     public GameObject TargetPlayer0Done;
     public GameObject TargetPlayer1Done;
     public GameObject TargetCanvas;
 
     int curPlayer = 0;
 
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
     /// <summary>
-    /// if curPlayer is 0, set "Player0Done" to match Canvas and change curPlayer to 1.
-    /// if curPlayer is 1, set "Player1DOne" to match Canvas and change curPlayer to 0.
+    /// Depending on curpPlayer, set "Player0Done" or "Player1Done" to match Canvas and change curPlayer.
+    /// change isOn of selected toggle to false.
     /// </summary>
     public void OnClickDoneButton()
     {
-        if (curPlayer == 0)
+        if (fingerToggleGroup.IsToggleClicked() == true) // check if player choose toggle
         {
-            TargetPlayer0Done.transform.position = TargetCanvas.transform.position;
+            if (curPlayer == 0)
+            {
+                TargetPlayer0Done.transform.position = TargetCanvas.transform.position;
+            }
+            else
+            {
+                TargetPlayer1Done.transform.position = TargetCanvas.transform.position;
+            }
+            curPlayer = (curPlayer == 0) ? 1 : 0;
+
+            switch (fingerToggleGroup.SelectedFinger)
+            {
+                case 0:
+                    ZeroButton.isOn = false;
+                    break;
+                case 1:
+                    OneButton.isOn = false;
+                    break;
+                case 2:
+                    TwoButton.isOn = false;
+                    break;
+                case 3:
+                    ThreeButton.isOn = false;
+                    break;
+                case 4:
+                    FourButton.isOn = false;
+                    break;
+                case 5:
+                    FiveButton.isOn = false;
+                    break;
+            }
         }
-        else
-        {
-            TargetPlayer1Done.transform.position = TargetCanvas.transform.position;
-        }
-        curPlayer = (curPlayer == 0) ? 1 : 0;
     }
 
     /// <summary>


### PR DESCRIPTION
1. 플레이어가 손가락을 선택했을 때만 "확인 버튼"이 작동하도록 했습니다.
2. "확인 버튼"이 작동하면 선택한 토글의 isOn이 false가 되도록 했습니다.

3. FingerToggle.cs의 불필요한 Debug.log 한 줄을 삭제했습니다.

"확인 버튼"을 누르면 FingerToggleGroup의 SelectedFinger이 -1로 즉시 변경되기 때문에 추후에 SelectedFinger를 저장할 수 있도록 UIManager.cs의 OnClickDoneButton() 함수 수정이 필요해보입니다.