### PR TITLE
백도 구현 방법 변경 및 TokenManager 수정

### DIFF
--- a/Assets/Prefabs/EmptyToken.prefab
+++ b/Assets/Prefabs/EmptyToken.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7124735917412138256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4737627480489859954}
+  - component: {fileID: 5698583884613481110}
+  m_Layer: 0
+  m_Name: EmptyToken
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4737627480489859954
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7124735917412138256}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5698583884613481110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7124735917412138256}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8aae729c056c8f9409f1763e34ab0ce0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/EmptyToken.prefab.meta
+++ b/Assets/Prefabs/EmptyToken.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 02f0fe28a38caa14da146aabb2e4774d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Yutnori.unity
+++ b/Assets/Scenes/Yutnori.unity
@@ -1468,6 +1468,7 @@ MonoBehaviour:
   - {x: -10, y: 75}
   - {x: 10, y: 75}
   - {x: 30, y: 75}
+  finishedPosition: {x: 50, y: -60}
 --- !u!4 &1678223111
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Yutnori.unity
+++ b/Assets/Scenes/Yutnori.unity
@@ -1458,6 +1458,7 @@ MonoBehaviour:
   - {fileID: 1853000956}
   tokenPrefab1: {fileID: 1033905997015866053, guid: 51c5ea11405bda541a80fe278a8c5f9b, type: 3}
   tokenPrefab2: {fileID: 864976361006012577, guid: d5fdb2da38a490c42a5c8377b4e21186, type: 3}
+  emptyTokenPrefab: {fileID: 7124735917412138256, guid: 02f0fe28a38caa14da146aabb2e4774d, type: 3}
   initialPositions1:
   - {x: -30, y: -75}
   - {x: -10, y: -75}

--- a/Assets/Scripts/Managers/TokenManager.cs
+++ b/Assets/Scripts/Managers/TokenManager.cs
@@ -196,6 +196,7 @@ public class TokenManager : MonoBehaviour
                 token.canFinish = true;
                 break;
             case BoardPointIndex.RightDiag1:
+            case BoardPointIndex.RightDiag3:
                 token.routeType = 2;
                 break;
             case BoardPointIndex.LeftDiag1:
@@ -218,6 +219,7 @@ public class TokenManager : MonoBehaviour
                 token.canFinish = true;
                 break;
             case BoardPointIndex.RightDiag1:
+            case BoardPointIndex.RightDiag3:
                 token.routeType = 2;
                 break;
             case BoardPointIndex.LeftDiag1:

--- a/Assets/Scripts/Managers/TokenManager.cs
+++ b/Assets/Scripts/Managers/TokenManager.cs
@@ -189,10 +189,12 @@ public class TokenManager : MonoBehaviour
         }
         else if (token.boardPointIndex == BoardPointIndex.RightDiag1)
         {
+            token.routeType = 0;
             yield return MoveTokenTo(token, BoardPointIndex.UpperRight);
         }
         else if (token.boardPointIndex == BoardPointIndex.LeftDiag1)
         {
+            token.routeType = 0;
             yield return MoveTokenTo(token, BoardPointIndex.UpperLeft);
         }
         else if (token.boardPointIndex == BoardPointIndex.LeftDiag3)

--- a/Assets/Scripts/Managers/TokenManager.cs
+++ b/Assets/Scripts/Managers/TokenManager.cs
@@ -46,7 +46,7 @@ public class TokenManager : MonoBehaviour
     [SerializeField] private List<Vector2> initialPositions1, initialPositions2;
     [SerializeField] private Vector2 finishedPosition; // TODO: Make an actual finishing position or animation?
 
-    private List<Token> tokens1, tokens2;
+    public List<Token> tokens1, tokens2;
 
     private void Start()
     {

--- a/Assets/Scripts/Token/Token.cs
+++ b/Assets/Scripts/Token/Token.cs
@@ -6,18 +6,23 @@ using System.Collections;
 
 public class Token : MonoBehaviour
 {
-    private bool _canFinish;        // False before first move
+    private bool _canFinish;  // false before moving out of lowerRightPoint
+    private bool _hasLooped;  // true if token has reached lowerRightPoint with forward movement
     private int _routeType;   // 0: right->upper->left->lower / 1: right->upper->leftDiag
                               // 2: right->rightDiag->lower   / 3: right->rightDiag->leftDiag
     private BoardPointIndex _boardPointIndex;
+    private Vector2 _initialPosition;
 
     public bool canFinish { get => _canFinish; set => _canFinish = value; }
+    public bool hasLooped { get => _hasLooped; set => _hasLooped = value; }
     public int routeType { get => _routeType; set => _routeType = value; }
     public BoardPointIndex boardPointIndex { get => _boardPointIndex; set => _boardPointIndex = value; }
+    public Vector2 initialPosition { get => _initialPosition; set => _initialPosition = value; }
 
     private void Awake()
     {
         _canFinish = false;
+        _hasLooped = false;
         _routeType = 0;
         _boardPointIndex = BoardPointIndex.Initial;
     }

--- a/Assets/Scripts/Token/Token.cs
+++ b/Assets/Scripts/Token/Token.cs
@@ -6,23 +6,20 @@ using System.Collections;
 
 public class Token : MonoBehaviour
 {
-    private bool _canFinish;        // Whether the token can finish on the next turn
-    private bool _isFinished;       // Whether the token has completed a lap
-    private bool _isFromLeftDiag;   // Whether the token came to center from leftDiag
-    private Vector2 _initialPosition;
-    private Vector2 _previousPosition;
+    private bool _canFinish;        // False before first move
+    private int _routeType;   // 0: right->upper->left->lower / 1: right->upper->leftDiag
+                             // 2: right->rightDiag->lower   / 3: right->rightDiag->leftDiag
+    private BoardPointIndex _boardPointIndex;
 
     public bool canFinish { get => _canFinish; set => _canFinish = value; }
-    public bool isFinished { get => _isFinished; set => _isFinished = value; }
-    public bool isFromLeftDiag { get => _isFromLeftDiag; set => _isFromLeftDiag = value; }
-    public Vector2 initialPosition { get => _initialPosition; set => _initialPosition = value; }
-    public Vector2 previousPosition { get => _previousPosition; set => _previousPosition = value; }
+    public int routeType { get => _routeType; set => _routeType = value; }
+    public BoardPointIndex boardPointIndex { get => _boardPointIndex; set => _boardPointIndex = value; }
 
     private void Awake()
     {
         _canFinish = false;
-        _isFinished = false;
-        _isFromLeftDiag = false;
+        _routeType = 0;
+        _boardPointIndex = BoardPointIndex.Initial;
     }
 
     private void Update()

--- a/Assets/Scripts/Token/Token.cs
+++ b/Assets/Scripts/Token/Token.cs
@@ -14,9 +14,9 @@ public class Token : MonoBehaviour
 
     public bool canFinish { get => _canFinish; set => _canFinish = value; }
     public bool isFinished { get => _isFinished; set => _isFinished = value; }
+    public bool isFromLeftDiag { get => _isFromLeftDiag; set => _isFromLeftDiag = value; }
     public Vector2 initialPosition { get => _initialPosition; set => _initialPosition = value; }
     public Vector2 previousPosition { get => _previousPosition; set => _previousPosition = value; }
-    public bool isFromLeftDiag { get => _isFromLeftDiag; set => _isFromLeftDiag = value; }
 
     private void Awake()
     {

--- a/Assets/Scripts/Token/Token.cs
+++ b/Assets/Scripts/Token/Token.cs
@@ -8,7 +8,7 @@ public class Token : MonoBehaviour
 {
     private bool _canFinish;        // False before first move
     private int _routeType;   // 0: right->upper->left->lower / 1: right->upper->leftDiag
-                             // 2: right->rightDiag->lower   / 3: right->rightDiag->leftDiag
+                              // 2: right->rightDiag->lower   / 3: right->rightDiag->leftDiag
     private BoardPointIndex _boardPointIndex;
 
     public bool canFinish { get => _canFinish; set => _canFinish = value; }

--- a/Assets/Scripts/Token/Token.cs
+++ b/Assets/Scripts/Token/Token.cs
@@ -6,15 +6,23 @@ using System.Collections;
 
 public class Token : MonoBehaviour
 {
-    private bool isFinished;    /// Whether the token has completed a lap
-    private Stack<Vector2> previousPositions;     /// Stores the token's previous positions for backward movement
+    private bool _canFinish;        // Whether the token can finish on the next turn
+    private bool _isFinished;       // Whether the token has completed a lap
+    private bool _isFromLeftDiag;   // Whether the token came to center from leftDiag
+    private Vector2 _initialPosition;
+    private Vector2 _previousPosition;
 
-    public bool IsFinished { get; set; }
+    public bool canFinish { get => _canFinish; set => _canFinish = value; }
+    public bool isFinished { get => _isFinished; set => _isFinished = value; }
+    public Vector2 initialPosition { get => _initialPosition; set => _initialPosition = value; }
+    public Vector2 previousPosition { get => _previousPosition; set => _previousPosition = value; }
+    public bool isFromLeftDiag { get => _isFromLeftDiag; set => _isFromLeftDiag = value; }
 
     private void Awake()
     {
-        isFinished = false;
-        previousPositions = new Stack<Vector2>();
+        _canFinish = false;
+        _isFinished = false;
+        _isFromLeftDiag = false;
     }
 
     private void Update()
@@ -41,7 +49,7 @@ public class Token : MonoBehaviour
     }
 
     /// <summary>
-    /// Moves token to newPosition smoothly; Use with StartCoroutine()
+    /// Moves token to newPosition smoothly and records previous position; Use with StartCoroutine()
     /// </summary>
     /// <param name="newPosition"></param>
     public IEnumerator MoveTo(Vector2 newPosition)
@@ -50,7 +58,7 @@ public class Token : MonoBehaviour
     }
 
     /// <summary>
-    /// Moves token to boardPoint smoothly; Use with StartCoroutine()
+    /// Moves token to boardPoint smoothly and records previous position; Use with StartCoroutine()
     /// </summary>
     /// <param name="boardPoint"></param>
     public IEnumerator MoveTo(GameObject boardPoint)
@@ -76,41 +84,5 @@ public class Token : MonoBehaviour
     public bool IsTokenAt(GameObject boardPoint)
     {
         return IsTokenAt(boardPoint.transform.position);
-    }
-
-    public void ClearPreviousPositions()
-    {
-        previousPositions.Clear();
-    }
-
-    /// <summary>
-    /// Pushes Token's current position into previousPositions
-    /// </summary>
-    public void RecordPosition()
-    {
-        previousPositions.Push(transform.position);
-    }
-
-    public int CountPreviousPositions()
-    {
-        return previousPositions.Count;
-    }
-
-    /// <summary>
-    /// Pops and returns top of previousPositions
-    /// </summary>
-    /// <returns></returns>
-    public Vector2 PopPreviousPositions()
-    {
-        return previousPositions.Pop();
-    }
-
-    /// <summary>
-    /// Returns top of previousPositions
-    /// </summary>
-    /// <returns></returns>
-    public Vector2 PeekPreviousPositions()
-    {
-        return previousPositions.Peek();
     }
 }


### PR DESCRIPTION
Token에서 previousPositions 스택을 삭제하고, 앞으로 움직일 때만 직전의 위치를 저장하는 previousPosition을 대신 넣었습니다.
Token마다 initialPosition을 따로 저장하도록 하였으며, previousPosition이 없을 때 null값으로 initialPosition을 사용했습니다.
previousPosition은 움직이기 시작할 때 initialPosition으로 초기화됩니다. 백도는 기본적으로 previousPosition으로 움직이나, 백도를 한 번 하면 previousPosition은 initialPosition으로 변경되어, 연속으로 백도를 하려고 하면 직선 경로 상의 뒤 지점으로 움직입니다.
또한, 백도 시 가야 할 위치를 결정하는 함수로 GetNextPositionBackward()를 추가했습니다.
이 외에도, 백도로 중앙에 갔다가 중앙에서 다시 백도 시 방향을 결정하기 위한 isFromLeftDiag 변수를 추가했습니다.